### PR TITLE
A storage abstraction for PSK

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -36,6 +36,7 @@ import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.CertificateTypeExtension.CertificateType;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 import org.eclipse.californium.scandium.util.ScProperties;
 
@@ -89,9 +90,11 @@ public class ClientHandshaker extends Handshaker {
 	 *            the message
 	 * @param session
 	 *            the session
+	 * @param pskStore
+	 *            storage for the pre-shared-keys 
 	 */
-	public ClientHandshaker(InetSocketAddress endpointAddress, RawData message, DTLSSession session) {
-		super(endpointAddress, true, session);
+	public ClientHandshaker(InetSocketAddress endpointAddress, RawData message, DTLSSession session,PskStore pskStore) {
+		super(endpointAddress, true, session, pskStore);
 		this.message = message;
 	}
 
@@ -432,7 +435,7 @@ public class ClientHandshaker extends Handshaker {
 		case PSK:
 			String identity = ScProperties.std.getProperty("PSK_IDENTITY");
 			clientKeyExchange = new PSKClientKeyExchange(identity);
-			byte[] psk = sharedKeys.get(identity);
+			byte[] psk = pskStore.getKey(identity);
 			
 			if (psk == null) {
 				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE);

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -23,6 +23,7 @@ import java.security.SecureRandom;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 
 
 /**
@@ -36,8 +37,8 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	
 	// Constructor ////////////////////////////////////////////////////
 
-	public ResumingClientHandshaker(InetSocketAddress endpointAddress, RawData message, DTLSSession session) {
-		super(endpointAddress, message, session);
+	public ResumingClientHandshaker(InetSocketAddress endpointAddress, RawData message, DTLSSession session, PskStore pskStore) {
+		super(endpointAddress, message, session, pskStore);
 	}
 	
 	// Methods ////////////////////////////////////////////////////////

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
@@ -22,6 +22,7 @@ import java.security.SecureRandom;
 
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 
 
 /**
@@ -40,8 +41,8 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 	
 	// Constructor ////////////////////////////////////////////////////
 
-	public ResumingServerHandshaker(InetSocketAddress endpointAddress, DTLSSession session) {
-		super(endpointAddress, session);
+	public ResumingServerHandshaker(InetSocketAddress endpointAddress, DTLSSession session, PskStore pskStore) {
+		super(endpointAddress, session, pskStore);
 		setSessionToResume(session);
 	}
 	

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -40,6 +40,7 @@ import org.eclipse.californium.scandium.dtls.CertificateTypeExtension.Certificat
 import org.eclipse.californium.scandium.dtls.SupportedPointFormatsExtension.ECPointFormat;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 import org.eclipse.californium.scandium.util.ScProperties;
 
@@ -86,9 +87,11 @@ public class ServerHandshaker extends Handshaker {
 	 *            the peer's address.
 	 * @param session
 	 *            the {@link DTLSSession}.
+	 * @param pskStore
+	 *            the storage for pre-shared-keys
 	 */
-	public ServerHandshaker(InetSocketAddress endpointAddress, DTLSSession session) {
-		super(endpointAddress, false, session);
+	public ServerHandshaker(InetSocketAddress endpointAddress, DTLSSession session, PskStore pskStore) {
+		super(endpointAddress, false, session,pskStore);
 
 		this.supportedCipherSuites = new ArrayList<CipherSuite>();
 		this.supportedCipherSuites.add(CipherSuite.SSL_NULL_WITH_NULL_NULL);
@@ -574,7 +577,7 @@ public class ServerHandshaker extends Handshaker {
 		// use the client's PSK identity to get right preshared key
 		String identity = message.getIdentity();
 
-		byte[] psk = sharedKeys.get(identity);
+		byte[] psk = pskStore.getKey(identity);
 		
 		if (LOGGER.isLoggable(Level.INFO)) {
 		    LOGGER.info("Client " + endpointAddress.toString() + " used PSK identity: " + identity);

--- a/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
+++ b/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
@@ -25,6 +25,8 @@ import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.ScandiumLogger;
+import org.eclipse.californium.scandium.dtls.pskstore.InMemoryPskStore;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.eclipse.californium.scandium.util.ScProperties;
 
 
@@ -41,7 +43,8 @@ public class ExampleDTLSClient {
 	private DTLSConnector dtlsConnector;
 	
 	public ExampleDTLSClient() {
-		dtlsConnector = new DTLSConnector(new InetSocketAddress(0));
+	    PskStore pskStore = new InMemoryPskStore();
+		dtlsConnector = new DTLSConnector(new InetSocketAddress(0), pskStore);
 		dtlsConnector.setRawDataReceiver(new RawDataChannelImpl());
 	}
 	


### PR DESCRIPTION
- introduce a PskStorage interface which is a simple way to get psk
  for a given identity
- a default in-memory implementation is provided for test/evaluation
  only, you need to be serious about the way you store your PSK and not
  keep them laying in your serer/client memoery
- apply dependency inversion principle for pushing the user defined
  PSK storage to the inner handshakers
- removed harcoded PSKs from Handshaker.java
- updated examples to show how to provide your own keys using the
  PskStore
