### PR TITLE
Store PSK Identity in the DTLS Session

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -434,9 +434,10 @@ public class ClientHandshaker extends Handshaker {
 
 		case PSK:
 			String identity = ScProperties.std.getProperty("PSK_IDENTITY");
+			session.setPskIdentity(identity);
+
 			clientKeyExchange = new PSKClientKeyExchange(identity);
 			byte[] psk = pskStore.getKey(identity);
-			
 			if (psk == null) {
 				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE);
 				throw new HandshakeException("No preshared secret found for identity: " + identity, alert);

--- a/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -67,6 +67,14 @@ public class DTLSSession {
 	private boolean isResumable = false;
 
 	/**
+	 * The identity used for PSK authentication
+	 */
+	private String pskIdentity;
+	
+	
+
+
+    /**
 	 * Whether the session is active and application data can be sent to the
 	 * peer.
 	 */
@@ -277,4 +285,12 @@ public class DTLSSession {
 	public InetSocketAddress getPeer() {
 		return peer;
 	}
+	
+	public String getPskIdentity() {
+        return pskIdentity;
+    }
+
+    public void setPskIdentity(String pskIdentity) {
+        this.pskIdentity = pskIdentity;
+    }	
 }

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -576,6 +576,7 @@ public class ServerHandshaker extends Handshaker {
 
 		// use the client's PSK identity to get right preshared key
 		String identity = message.getIdentity();
+		session.setPskIdentity(identity);
 
 		byte[] psk = pskStore.getKey(identity);
 		


### PR DESCRIPTION
Once the DTLS session is started successfully the applicative level will
want to know the used identity.

So I'm storing it in the DTLS session
