### PR TITLE
add an API to get the DTLSSession for a given peer address on DTLSConnector

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -473,7 +473,20 @@ public class DTLSConnector extends ConnectorBase {
 		flight.setSession(session);
 		sendFlight(flight);
 	}
-	
+
+	/**
+	 * Returns the {@link DTLSSession} related to the given peer address.
+	 * 
+	 * @param address the peer address
+	 * @return the {@link DTLSSession} or <code>null</code> if no session found.
+	 */
+	public DTLSSession getSessionByAddress(InetSocketAddress address) {
+		if (address == null) {
+			return null;
+		}
+		return dtlsSessions.get(addressToKey(address));
+	}
+
 	/**
 	 * Searches through all stored sessions and returns that session which
 	 * matches the session identifier or <code>null</code> if no such session


### PR DESCRIPTION
In Leshan we need an api on DTLSConnector to have access to DTLS session for a given peer address. We need to be able to  check if the identity (PSK) is the good one for a given endpoint.
