### PR TITLE
fix 446954: turn Scandium into an OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.eclipse.californium</groupId>
 	<artifactId>scandium</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>Scandium (Sc)</name>
 	<description>Security for Californium</description>
@@ -199,6 +199,31 @@
 					</excludes>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            org.eclipse.californium.scandium,
+                            org.eclipse.californium.scandium.dtls,
+                            org.eclipse.californium.scandium.dtls.pskstore
+                        </Export-Package>
+                        <Private-Package>
+                        	org.eclipse.californium.scandium.dtls.cipher,
+                        	org.eclipse.californium.scandium.examples,
+                        	org.eclipse.californium.scandium.util
+                        </Private-Package>
+                        <Import-Package>
+                            org.eclipse.californium.*;version="[1.0.0, 1.1)",
+                            *
+                        </Import-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
I have configured Maven Bundle plugin to add OSGi entries to Manifest.mf
Without Scandium being an OSGi bundle we would need to do ugly inlining of Scandium packages into the Leshan bundle in order to use Leshan in an OSGi framework ...
