### PR TITLE
add API to get RPK on DTLSSession

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -341,6 +341,7 @@ public class ClientHandshaker extends Handshaker {
 
 		serverCertificate = message;
 		serverPublicKey = serverCertificate.getPublicKey();
+		session.setPeerRawPublicKey(serverPublicKey);
 		serverCertificate.verifyCertificate(rootCertificates);
 	}
 

--- a/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -17,6 +17,7 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
+import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,11 +71,13 @@ public class DTLSSession {
 	 * The identity used for PSK authentication
 	 */
 	private String pskIdentity;
-	
-	
 
+	/**
+	 * The peer public key for RPK authentication
+	 */
+	private PublicKey peerRawPublicKey;	
 
-    /**
+	/**
 	 * Whether the session is active and application data can be sent to the
 	 * peer.
 	 */
@@ -142,6 +145,14 @@ public class DTLSSession {
 
 	public void setPeerCertificate(X509Certificate peerCertificate) {
 		this.peerCertificate = peerCertificate;
+	}
+
+	public PublicKey getPeerRawPublicKey() {
+		return peerRawPublicKey;
+	}
+
+	public void setPeerRawPublicKey(PublicKey key) {
+		peerRawPublicKey = key;
 	}
 
 	public CompressionMethod getCompressionMethod() {

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -256,6 +256,7 @@ public class ServerHandshaker extends Handshaker {
 		clientCertificate = message;
 		clientCertificate.verifyCertificate(rootCertificates);
 		clientPublicKey = clientCertificate.getPublicKey();
+		session.setPeerRawPublicKey(clientPublicKey);
 		
 		// TODO why don't we also update the MessageDigest at this point?
 		handshakeMessages = ByteArrayUtils.concatenate(handshakeMessages, clientCertificate.getRawMessage());


### PR DESCRIPTION
For leshan, we need to get the public key of a DTLSSession.
(see [discussion](http://dev.eclipse.org/mhonarc/lists/cf-dev/msg00132.html) on mailing list archive)
