### PR TITLE
manage empty sessionID

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -496,7 +496,7 @@ public class DTLSConnector extends ConnectorBase {
 	 *         <code>null</code> if no such session exists.
 	 */
 	private DTLSSession getSessionByIdentifier(byte[] sessionID) {
-		if (sessionID == null) {
+		if (sessionID == null || sessionID.length == 0) {
 			return null;
 		}
 		


### PR DESCRIPTION
When we try to retrieve a session from a sessionID, empty array of bytes should be not considered as valid sessionID.
