### PR TITLE
Fix handling of unsupported compression methods

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
@@ -18,6 +18,8 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.californium.scandium.util.DatagramReader;
 import org.eclipse.californium.scandium.util.DatagramWriter;
@@ -29,6 +31,10 @@ import org.eclipse.californium.scandium.util.DatagramWriter;
 public enum CompressionMethod {
 	NULL(0x00);
 	
+	// Logging ////////////////////////////////////////////////////////
+
+	private static final Logger LOGGER = Logger.getLogger(CompressionMethod.class.getCanonicalName());
+
 	// DTLS-specific constants ////////////////////////////////////////
 
 	private static final int COMPRESSION_METHOD_BITS = 8;
@@ -55,7 +61,10 @@ public enum CompressionMethod {
 			return CompressionMethod.NULL;
 
 		default:
-			return null;
+			if (LOGGER.isLoggable(Level.INFO)) {
+			    LOGGER.info("Unknown compression method code, fallback to NULL: " + code);
+			}
+			return CompressionMethod.NULL;
 		}
 	}
 	

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -108,6 +108,8 @@ public class ServerHandshaker extends Handshaker {
 		this.supportedCipherSuites.add(CipherSuite.SSL_NULL_WITH_NULL_NULL);
 		this.supportedCipherSuites.add(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8);
 		this.supportedCipherSuites.add(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
+		this.supportedCipherSuites.add(CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256);
+		this.supportedCipherSuites.add(CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA);
 		
 		this.pskStore = config.pskStore;
 		

--- a/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -38,8 +38,10 @@ public enum CipherSuite {
 	// Cipher suites //////////////////////////////////////////////////
 	
 	SSL_NULL_WITH_NULL_NULL("SSL_NULL_WITH_NULL_NULL", 0x0000, KeyExchangeAlgorithm.NULL, BulkCipherAlgorithm.NULL, MACAlgorithm.NULL, PRFAlgorithm.TLS_PRF_SHA256, CipherType.NULL),
-	TLS_PSK_WITH_AES_128_CCM_8("TLS_PSK_WITH_AES_128_CCM_8", 0xC0A8, KeyExchangeAlgorithm.PSK, BulkCipherAlgorithm.AES,	MACAlgorithm.NULL, PRFAlgorithm.TLS_PRF_SHA256,	CipherType.AEAD),
-	TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8("TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8", 0xC0AE, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, BulkCipherAlgorithm.AES, MACAlgorithm.NULL, PRFAlgorithm.TLS_PRF_SHA256, CipherType.AEAD);
+	TLS_PSK_WITH_AES_128_CCM_8("TLS_PSK_WITH_AES_128_CCM_8", 0xC0A8, KeyExchangeAlgorithm.PSK, BulkCipherAlgorithm.AES_CCM,	MACAlgorithm.NULL, PRFAlgorithm.TLS_PRF_SHA256,	CipherType.AEAD),
+	TLS_PSK_WITH_AES_128_CBC_SHA256("TLS_PSK_WITH_AES_128_CBC_SHA256", 0x00AE, KeyExchangeAlgorithm.PSK, BulkCipherAlgorithm.AES_CBC,	MACAlgorithm.NULL, PRFAlgorithm.TLS_PRF_SHA256,	CipherType.BLOCK),
+	TLS_PSK_WITH_AES_128_CBC_SHA("TLS_PSK_WITH_AES_128_CBC_SHA", 0x008C, KeyExchangeAlgorithm.PSK, BulkCipherAlgorithm.AES_CBC,	MACAlgorithm.HMAC_SHA1, PRFAlgorithm.TLS_PRF_SHA256,	CipherType.BLOCK),
+	TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8("TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8", 0xC0AE, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, BulkCipherAlgorithm.AES_CCM, MACAlgorithm.NULL, PRFAlgorithm.TLS_PRF_SHA256, CipherType.AEAD);
 	
 	// Logging ////////////////////////////////////////////////////////
 
@@ -118,14 +120,21 @@ public enum CipherSuite {
 		switch (code) {
 		case 0x0000:
 			return CipherSuite.SSL_NULL_WITH_NULL_NULL;
+		case 0x00AE:
+			return CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256;
+		case 0x008C:
+			if (LOGGER.isLoggable(Level.WARNING)) {
+				LOGGER.warning("Client specified a cipher suite with SHA-1: " + code);
+			}
+			return CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA;
 		case 0xC0A8:
 			return CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 		case 0xC0AE:
 			return CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8;
 
 		default:
-			if (LOGGER.isLoggable(Level.WARNING)) {
-			    LOGGER.warning("Unknown cipher suite code, fallback to SSL_NULL_WITH_NULL_NULL: " + code);
+			if (LOGGER.isLoggable(Level.INFO)) {
+			   LOGGER.info("Unknown cipher suite code, fallback to SSL_NULL_WITH_NULL_NULL: " + code);
 			}
 			return CipherSuite.SSL_NULL_WITH_NULL_NULL;
 		}
@@ -175,7 +184,8 @@ public enum CipherSuite {
 		NULL(0, 0, 0, 0),
 		RC4(0, 16, 4, 8), // don't know
 		B_3DES(0, 16, 4, 8), // don't know
-		AES(0, 16, 4, 8); // http://www.ietf.org/mail-archive/web/tls/current/msg08445.html
+		AES_CBC(32, 16, 16, 8),
+		AES_CCM(0, 16, 4, 8); // http://www.ietf.org/mail-archive/web/tls/current/msg08445.html
 		
 		// values in octets!
 		private int macKeyLength;

--- a/src/main/java/org/eclipse/californium/scandium/util/ByteArrayUtils.java
+++ b/src/main/java/org/eclipse/californium/scandium/util/ByteArrayUtils.java
@@ -48,6 +48,23 @@ public class ByteArrayUtils {
 		}
 
 	}
+	/**
+	 * Adds the minimum amount of TLS-CBC-style padding in order to make the array
+	 * size a multiple of the block size. NOTE: if the array is already a multiple 
+	 * of the block size this will add an entire block, as required in RFC5246
+	 * 
+	 * @param array
+	 *            the array to be padded.
+	 * @param blockSize
+	 *            Block size of the cipher - usually 16
+	 * @return a new array strictly larger than the given one
+	 */
+	public static byte[] padArray(byte[] array, int blockSize) {
+		int requiredLength = (array.length / blockSize + 1) * blockSize;
+		byte padding = (byte) (requiredLength - array.length - 1);
+
+		return padArray(array, padding, requiredLength);
+	}	
 
 	/**
 	 * Truncates the given array to the request length.


### PR DESCRIPTION
Returning null causes a NullPointerException if the client suggests ANY compression methods. This new code is similar to CipherSuite.