### PR TITLE
Fix cipher negotiation

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -300,8 +300,10 @@ public class ClientHandshaker extends Handshaker {
 	 * 
 	 * @param message
 	 *            the {@link ServerHello} message.
+	 * @throws HandshakeException if the ServerHello message cannot be processed,
+	 * 	e.g. because the server selected an unknown or unsupported cipher suite
 	 */
-	private void receivedServerHello(ServerHello message) {
+	private void receivedServerHello(ServerHello message) throws HandshakeException {
 		if (serverHello != null && (message.getMessageSeq() == serverHello.getMessageSeq())) {
 			// received duplicate version (retransmission), discard it
 			return;

--- a/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -39,6 +39,8 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
@@ -783,8 +785,14 @@ public abstract class Handshaker {
 	 * 
 	 * @param cipherSuite
 	 *            the cipher suite.
+	 * @throws HandshakeException if the given cipher suite is <code>null</code>
+	 * 	or {@link CipherSuite#SSL_NULL_WITH_NULL_NULL}
 	 */
-	public void setCipherSuite(CipherSuite cipherSuite) {
+	void setCipherSuite(CipherSuite cipherSuite) throws HandshakeException {
+		if (cipherSuite == null || CipherSuite.SSL_NULL_WITH_NULL_NULL == cipherSuite) {
+			throw new HandshakeException("Negotiated cipher suite must not be null",
+					new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE));
+		}
 		this.cipherSuite = cipherSuite;
 		this.keyExchange = cipherSuite.getKeyExchange();
 		this.session.setKeyExchange(keyExchange);

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
@@ -13,11 +13,20 @@
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
  *    Stefan Jucker - DTLS implementation
+ *    Kai Hudalla - documentation
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
 /**
- * Represents the protocol version.
+ * Represents the DTLS protocol version.
+ * 
+ * Note that the major and minor version numbers are represented
+ * as the 1's complement of the corresponding DTLS version numbers,
+ * e.g. DTLS version 1.2 is represented as bytes {254, 253}.
+ * 
+ * See <a href="http://tools.ietf.org/html/rfc6347#section-4.1">
+ * Datagram Transport Layer Security Version 1.2 (RFC 6347), Section 4.1</a>
+ * for details.
  */
 public class ProtocolVersion implements Comparable<ProtocolVersion> {
 	
@@ -28,7 +37,9 @@ public class ProtocolVersion implements Comparable<ProtocolVersion> {
 	private int major;
 	
 	/**
-	 * The latest version supported.
+	 * Creates an instance representing DTLS version 1.2.
+	 * 
+	 * The version is represented as {254, 253} (1's complement of {1, 2}).
 	 */
 	public ProtocolVersion() {
 		this.major = 254;
@@ -55,7 +66,20 @@ public class ProtocolVersion implements Comparable<ProtocolVersion> {
 		return major;
 	}
 
-	//@Override
+	/**
+	 * Compares this protocol version to another one.
+	 * 
+	 * Note that the comparison is done based on the <em>semantic</em> version,
+	 * i.e. DTLS protocol version 1.0 (represented as major 254, minor 255) is considered
+	 * <em>lower</em> than 1.2 (represented as major 254, minor 253) whereas the
+	 * byte values representing version 1.0 are actually larger.
+	 * 
+	 * @param o the protocol version to compare to
+	 * @return <em>0</em> if this version is exactly the same as the other version,
+	 *         <em>-1</em> if this version is lower than the other version or
+	 *         <em>1</em> if this version is higher than the other version
+	 */
+	@Override
 	public int compareTo(ProtocolVersion o) {
 		/*
 		 * Example, version 1.0 (254,255) is smaller than version 1.2 (254,253)

--- a/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -26,12 +26,14 @@ import org.eclipse.californium.scandium.util.DatagramWriter;
 
 
 /**
- * A cipher suite defines key exchange algorithm, the bulk cipher algorithm, the
- * mac algorithm, the prf algorithm and the cipher type. See <a
- * href="http://tools.ietf.org/html/rfc5246#appendix-A.6">RFC 5246</a> for
- * details. See <a
- * href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xml"
- * >IANA</a> for Transport Layer Security Parameters.
+ * A cipher suite defines a key exchange algorithm, a bulk cipher algorithm, a
+ * MAC algorithm, a pseudo random number (PRF) algorithm and a cipher type.
+ * 
+ * See <a href="http://tools.ietf.org/html/rfc5246#appendix-A.6">RFC 5246</a>
+ * for details.
+ * See <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml">
+ * Transport Layer Security Parameters</a> for the official codes for the cipher
+ * suites.
  */
 public enum CipherSuite {
 	
@@ -109,10 +111,10 @@ public enum CipherSuite {
 	}
 
 	/**
-	 * Returns the cipher suite to a given code.
+	 * Gets a cipher suite by its numeric code.
 	 * 
-	 * @param code the numeric code of the cipher suite (usually hexadecimal)
-	 * @return the according cipher suite.
+	 * @param code the cipher's <a href="">IANA assigned code</a>
+	 * @return the cipher suite or <code>null</code> if the code is unknown
 	 */
 	public static CipherSuite getTypeByCode(int code) {
 		switch (code) {
@@ -124,10 +126,12 @@ public enum CipherSuite {
 			return CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8;
 
 		default:
-			if (LOGGER.isLoggable(Level.WARNING)) {
-			    LOGGER.warning("Unknown cipher suite code, fallback to SSL_NULL_WITH_NULL_NULL: " + code);
+			if (LOGGER.isLoggable(Level.FINE)) {
+			    LOGGER.log(Level.FINE,
+			    		"Cannot resolve cipher suite code [{0}]",
+			    		Integer.toHexString(code));
 			}
-			return CipherSuite.SSL_NULL_WITH_NULL_NULL;
+			return null;
 		}
 	}
 
@@ -156,7 +160,12 @@ public enum CipherSuite {
 
 		for (int i = 0; i < numElements; i++) {
 			int code = reader.read(CIPHER_SUITE_BITS);
-			cipherSuites.add(CipherSuite.getTypeByCode(code));
+			CipherSuite cipher = CipherSuite.getTypeByCode(code);
+			// simply ignore unknown cipher suites as mandated by
+			// RFC 5246, Section 7.4.1.2 Client Hello
+			if (cipher != null) {
+				cipherSuites.add(cipher);
+			}
 		}
 		return cipherSuites;
 	}


### PR DESCRIPTION
I have changed the CipherSuite implementation to **not** fall back to the `SSL_NULL...` cipher suite but instead return `null`. I have also added code for explicitly handling this case in the Handshakers.