### PR TITLE
Modified client authentication.

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -358,7 +358,7 @@ public class ClientHandshaker extends Handshaker {
 		}
 
 		serverCertificate = message;
-		serverCertificate.verifyCertificate(rootCertificates);
+		serverCertificate.verifyCertificate(rootCertificates, false);
 		serverPublicKey = serverCertificate.getPublicKey();
 		if (message.getCertificateChain() != null) {
 			peerCertificate = (X509Certificate) message.getCertificateChain()[0];

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -308,7 +308,7 @@ public class ServerHandshaker extends Handshaker {
 		}
 
 		clientCertificate = message;
-		clientCertificate.verifyCertificate(rootCertificates);
+		clientCertificate.verifyCertificate(rootCertificates, clientAuthenticationRequired);
 		clientPublicKey = clientCertificate.getPublicKey();
 		if (message.getCertificateChain() != null) {
 			peerCertificate = (X509Certificate) message.getCertificateChain()[0];


### PR DESCRIPTION
Hi all,

here would be my code changes to allow proper client modification. Comments or improvements are always welcome.

One issue that occurs in the case (clientAuthenticationRequired == true) && (isSelfSigned(peerCertificate) == true) I got the following NullPointerException. Any ideas?

14 INFO [CertificateMessage]: Peer used self-signed certificate. - (org.eclipse.californium.scandium.dtls.CertificateMessage.java:216) verifyCertificate() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:36)
14 FINE [DTLSConnector]: Cannot process [Handshake (22)] record from peer [/127.0.0.1:35180] due to [Peer used self-signed certificate, no client authentication possible.], aborting handshake ... - (org.eclipse.californium.scandium.DTLSConnector.java:92) receiveNextDatagramFromNetwork() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:36)
14 FINE [DTLSConnector]: Terminating connection with peer [/127.0.0.1:35180], reason [UNKNOWN_CA] - (org.eclipse.californium.scandium.DTLSConnector.java:431) terminateConnection() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:36)
14 FINER [DTLSConnector]: Received HANDSHAKE record from peer [/127.0.0.1:35180] - (org.eclipse.californium.scandium.DTLSConnector.java:411) processHandshakeRecord() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:36)
14 FINE [DTLSConnector$Worker]: Exception thrown by worker thread [DTLS-Receiver-0.0.0.0/0.0.0.0:5684] - (org.eclipse.californium.scandium.DTLSConnector$Worker.java:1018) run() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:36)
java.lang.NullPointerException
	at org.eclipse.californium.scandium.DTLSConnector.processHandshakeRecord(DTLSConnector.java:583)
	at org.eclipse.californium.scandium.DTLSConnector.receiveNextDatagramFromNetwork(DTLSConnector.java:411)
	at org.eclipse.californium.scandium.DTLSConnector.access$500(DTLSConnector.java:92)
	at org.eclipse.californium.scandium.DTLSConnector$3.doWork(DTLSConnector.java:336)
	at org.eclipse.californium.scandium.DTLSConnector$Worker.run(DTLSConnector.java:1013)
14 FINER [DTLSConnector]: Received HANDSHAKE record from peer [/127.0.0.1:35180] - (org.eclipse.californium.scandium.DTLSConnector.java:411) processHandshakeRecord() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:37)
14 FINE [DTLSConnector$Worker]: Exception thrown by worker thread [DTLS-Receiver-0.0.0.0/0.0.0.0:5684] - (org.eclipse.californium.scandium.DTLSConnector$Worker.java:1018) run() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:37)
java.lang.NullPointerException
	at org.eclipse.californium.scandium.DTLSConnector.processHandshakeRecord(DTLSConnector.java:583)
	at org.eclipse.californium.scandium.DTLSConnector.receiveNextDatagramFromNetwork(DTLSConnector.java:411)
	at org.eclipse.californium.scandium.DTLSConnector.access$500(DTLSConnector.java:92)
	at org.eclipse.californium.scandium.DTLSConnector$3.doWork(DTLSConnector.java:336)
	at org.eclipse.californium.scandium.DTLSConnector$Worker.run(DTLSConnector.java:1013)
14 FINER [DTLSConnector]: Received HANDSHAKE record from peer [/127.0.0.1:35180] - (org.eclipse.californium.scandium.DTLSConnector.java:411) processHandshakeRecord() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:37)
14 FINE [DTLSConnector$Worker]: Exception thrown by worker thread [DTLS-Receiver-0.0.0.0/0.0.0.0:5684] - (org.eclipse.californium.scandium.DTLSConnector$Worker.java:1018) run() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:37)
java.lang.NullPointerException
	at org.eclipse.californium.scandium.DTLSConnector.processHandshakeRecord(DTLSConnector.java:583)
	at org.eclipse.californium.scandium.DTLSConnector.receiveNextDatagramFromNetwork(DTLSConnector.java:411)
	at org.eclipse.californium.scandium.DTLSConnector.access$500(DTLSConnector.java:92)
	at org.eclipse.californium.scandium.DTLSConnector$3.doWork(DTLSConnector.java:336)
	at org.eclipse.californium.scandium.DTLSConnector$Worker.run(DTLSConnector.java:1013)
14 FINER [DTLSConnector]: Received HANDSHAKE record from peer [/127.0.0.1:35180] - (org.eclipse.californium.scandium.DTLSConnector.java:411) processHandshakeRecord() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:38)
14 FINE [DTLSConnector$Worker]: Exception thrown by worker thread [DTLS-Receiver-0.0.0.0/0.0.0.0:5684] - (org.eclipse.californium.scandium.DTLSConnector$Worker.java:1018) run() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:38)
java.lang.NullPointerException
	at org.eclipse.californium.scandium.DTLSConnector.processHandshakeRecord(DTLSConnector.java:583)
	at org.eclipse.californium.scandium.DTLSConnector.receiveNextDatagramFromNetwork(DTLSConnector.java:411)
	at org.eclipse.californium.scandium.DTLSConnector.access$500(DTLSConnector.java:92)
	at org.eclipse.californium.scandium.DTLSConnector$3.doWork(DTLSConnector.java:336)
	at org.eclipse.californium.scandium.DTLSConnector$Worker.run(DTLSConnector.java:1013)
14 FINER [DTLSConnector]: Received HANDSHAKE record from peer [/127.0.0.1:35180] - (org.eclipse.californium.scandium.DTLSConnector.java:411) processHandshakeRecord() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:39)
14 FINE [DTLSConnector$Worker]: Exception thrown by worker thread [DTLS-Receiver-0.0.0.0/0.0.0.0:5684] - (org.eclipse.californium.scandium.DTLSConnector$Worker.java:1018) run() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:39)
java.lang.NullPointerException
	at org.eclipse.californium.scandium.DTLSConnector.processHandshakeRecord(DTLSConnector.java:583)
	at org.eclipse.californium.scandium.DTLSConnector.receiveNextDatagramFromNetwork(DTLSConnector.java:411)
	at org.eclipse.californium.scandium.DTLSConnector.access$500(DTLSConnector.java:92)
	at org.eclipse.californium.scandium.DTLSConnector$3.doWork(DTLSConnector.java:336)
	at org.eclipse.californium.scandium.DTLSConnector$Worker.run(DTLSConnector.java:1013)
14 FINER [DTLSConnector]: Received HANDSHAKE record from peer [/127.0.0.1:35180] - (org.eclipse.californium.scandium.DTLSConnector.java:411) processHandshakeRecord() in thread DTLS-Receiver-0.0.0.0/0.0.0.0:5684 at (2015-06-01 19:23:39)
14 FINE [DTLSConnector]: Processing CLIENT_HELLO from peer [/127.0.0.1:35180]: