### PR TITLE
fix certificate types extensions config for rpk/x509 handshake.

### DIFF
--- a/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -29,6 +29,8 @@ import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,13 +76,19 @@ public class ClientHandshaker extends Handshaker {
 	/** the preferred cipher suites ordered by preference */
 	private final CipherSuite[] preferredCipherSuites;
 
-	/** whether the certificate message should only contain the peer's public key or the full X.509 certificate */
-	private final boolean useRawPublicKey;
-	
 	/** The raw message that triggered the start of the handshake
 	 * and needs to be sent once the session is established.
 	 * */
 	private final RawData message;
+
+	/**
+	 * The certificate types this server supports for client authentication.
+	 */
+	private List<CertificateType> supportedClientCertificateTypes;
+	/**
+	 * The certificate types this server supports for server authentication.
+	 */
+	private List<CertificateType> supportedServerCertificateTypes;
 
 	/*
 	 * Store all the message which can possibly be sent by the server.
@@ -129,10 +137,30 @@ public class ClientHandshaker extends Handshaker {
 		this.certificates = config.getCertificateChain();
 		this.publicKey = config.getPublicKey();
 		this.pskStore = config.getPskStore();
-		this.useRawPublicKey = config.isSendRawKey();
 		this.preferredCipherSuites = config.getSupportedCipherSuites();
+
+		this.supportedServerCertificateTypes = new ArrayList<>();
+		this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+		if (rootCertificates != null && rootCertificates.length > 0) {
+			this.supportedServerCertificateTypes.add(CertificateType.X_509);
+		}
+
+		this.supportedClientCertificateTypes = new ArrayList<>();
+		if (privateKey != null && publicKey != null) {
+			if (certificates != null) {
+				if (config.isSendRawKey()) {
+					this.supportedClientCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+					this.supportedClientCertificateTypes.add(CertificateType.X_509);
+				} else {
+					this.supportedClientCertificateTypes.add(CertificateType.X_509);
+					this.supportedClientCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+				}
+			} else {
+				this.supportedClientCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+			}
+		}
 	}
-	
+
 	// Methods ////////////////////////////////////////////////////////
 	
 
@@ -581,7 +609,7 @@ public class ClientHandshaker extends Handshaker {
 	@Override
 	public DTLSFlight getStartHandshakeMessage() throws HandshakeException {
 		handshakeStarted();
-		ClientHello message = new ClientHello(maxProtocolVersion, new SecureRandom(), useRawPublicKey, session.getPeer());
+		ClientHello message = new ClientHello(maxProtocolVersion, new SecureRandom(),supportedClientCertificateTypes, supportedServerCertificateTypes, session.getPeer() );
 
 		// store client random for later calculations
 		clientRandom = message.getRandom();

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
@@ -99,12 +99,13 @@ public final class ClientHello extends HandshakeMessage {
 	 *  
 	 * @param version the protocol version to use
 	 * @param secureRandom a function to use for creating random values included in the message
-	 * @param useRawPublicKey <code>true</code> if this client prefers <em>raw public keys</em> over
-	 *           <em>X.509</em> certificates to be used for (mutual) authentication
+	 * @param supportedClientCertificateTypes the list of certificate types supported by the client
+	 * @param supportedServerCertificateTypes the list of certificate types supported by the server
 	 * @param peerAddress the IP address and port of the peer this
 	 *           message has been received from or should be sent to
 	 */
-	public ClientHello(ProtocolVersion version, SecureRandom secureRandom, boolean useRawPublicKey, InetSocketAddress peerAddress) {
+	public ClientHello(ProtocolVersion version, SecureRandom secureRandom, List<CertificateType> supportedClientCertificateTypes,
+			List<CertificateType> supportedServerCertificateTypes, InetSocketAddress peerAddress) {
 
 		this(version, secureRandom, null, peerAddress);
 		this.extensions = new HelloExtensions();
@@ -125,35 +126,22 @@ public final class ClientHello extends HandshakeMessage {
 		this.extensions.addExtension(supportedPointFormatsExtension);
 		
 		// the certificate types the client is able to provide to the server
-		CertificateTypeExtension clientCertificateType = new ClientCertificateTypeExtension(true);
-		if (useRawPublicKey) {
-			clientCertificateType.addCertificateType(CertificateType.RAW_PUBLIC_KEY);
-			clientCertificateType.addCertificateType(CertificateType.X_509);
-		} else {
-			// the client supports rawPublicKeys but prefers X.509 certificates
-			
-			// http://tools.ietf.org/html/draft-ietf-tls-oob-pubkey-07#section-3:
-			// this extension MUST be omitted if the client only supports X.509 certificates
-			clientCertificateType.addCertificateType(CertificateType.X_509);
-			clientCertificateType.addCertificateType(CertificateType.RAW_PUBLIC_KEY);
+		if (!supportedClientCertificateTypes.isEmpty()) {
+			CertificateTypeExtension clientCertificateType = new ClientCertificateTypeExtension(true);
+			for (CertificateType certificateType : supportedClientCertificateTypes) {
+				clientCertificateType.addCertificateType(certificateType);
+			}
+			this.extensions.addExtension(clientCertificateType);
 		}
-		
+
 		// the type of certificates the client is able to process when provided by the server
-		CertificateTypeExtension serverCertificateType = new ServerCertificateTypeExtension(true);
-		if (useRawPublicKey) {
-			serverCertificateType.addCertificateType(CertificateType.RAW_PUBLIC_KEY);
-			serverCertificateType.addCertificateType(CertificateType.X_509);
-		} else {
-			// the client supports rawPublicKeys but prefers X.509 certificates
-			
-			// http://tools.ietf.org/html/draft-ietf-tls-oob-pubkey-07#section-3:
-			// this extension MUST be omitted if the client only supports X.509 certificates
-			serverCertificateType.addCertificateType(CertificateType.X_509);
-			serverCertificateType.addCertificateType(CertificateType.RAW_PUBLIC_KEY);
+		if (!supportedServerCertificateTypes.isEmpty()) {
+			CertificateTypeExtension serverCertificateType = new ServerCertificateTypeExtension(true);
+			for (CertificateType certificateType : supportedServerCertificateTypes) {
+				serverCertificateType.addCertificateType(certificateType);
+			}
+			this.extensions.addExtension(serverCertificateType);
 		}
-		
-		this.extensions.addExtension(clientCertificateType);
-		this.extensions.addExtension(serverCertificateType);
 	}
 
 	/**

--- a/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -161,21 +161,26 @@ public class ServerHandshaker extends Handshaker {
 
 		this.supportedClientCertificateTypes = new ArrayList<>();
 		this.supportedClientCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
-		if (rootCertificates != null) {
+		if (rootCertificates != null && rootCertificates.length > 0) {
 			this.supportedClientCertificateTypes.add(CertificateType.X_509);
 		}
 
 		this.supportedServerCertificateTypes = new ArrayList<>();
 		if (privateKey != null && publicKey != null) {
-			if (config.isSendRawKey()) {
-				this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
-			}
 			if (certificates != null) {
-				this.supportedServerCertificateTypes.add(CertificateType.X_509);
+				if (config.isSendRawKey()) {
+					this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+					this.supportedServerCertificateTypes.add(CertificateType.X_509);
+				} else {
+					this.supportedServerCertificateTypes.add(CertificateType.X_509);
+					this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+				}
+			} else {
+				this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
 			}
 		}
 	}
-	
+
 	// Methods ////////////////////////////////////////////////////////
 	
 

--- a/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -36,6 +36,7 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +49,7 @@ import org.eclipse.californium.scandium.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.scandium.category.Medium;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.CertificateTypeExtension.CertificateType;
 import org.eclipse.californium.scandium.dtls.ClientHello;
 import org.eclipse.californium.scandium.dtls.CompressionMethod;
 import org.eclipse.californium.scandium.dtls.ContentType;
@@ -491,9 +493,9 @@ public class DTLSConnectorTest {
 	private ClientHello createClientHello(DTLSSession sessionToResume) {
 		ClientHello hello = null;
 		if (sessionToResume == null) {
-			hello = new ClientHello(new ProtocolVersion(), new SecureRandom(), false, clientEndpoint);
+			hello = new ClientHello(new ProtocolVersion(), new SecureRandom(), Collections.<CertificateType> emptyList(), Collections.<CertificateType> emptyList(),clientEndpoint);
 		} else {
-			hello = new ClientHello(new ProtocolVersion(), new SecureRandom(), sessionToResume);
+			hello = new ClientHello(new ProtocolVersion(), new SecureRandom(),sessionToResume);
 		}
 		hello.addCipherSuite(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8);
 		hello.addCipherSuite(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);

--- a/src/test/java/org/eclipse/californium/scandium/dtls/ClientHelloTest.java
+++ b/src/test/java/org/eclipse/californium/scandium/dtls/ClientHelloTest.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.*;
 
 import java.net.InetSocketAddress;
 import java.security.SecureRandom;
+import java.util.Collections;
 
 import org.eclipse.californium.scandium.category.Small;
+import org.eclipse.californium.scandium.dtls.CertificateTypeExtension.CertificateType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,6 +48,6 @@ public class ClientHelloTest {
 	}
 	
 	private void givenAClientHelloWithEmptyExtensions() {
-		clientHello = new ClientHello(new ProtocolVersion(), new SecureRandom(), false, peerAddress);
+		clientHello = new ClientHello(new ProtocolVersion(), new SecureRandom(), Collections.<CertificateType> emptyList(), Collections.<CertificateType> emptyList(), peerAddress);
 	}
 }

--- a/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -19,9 +19,11 @@ package org.eclipse.californium.scandium.dtls;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
@@ -60,11 +62,18 @@ public class ServerHandshakerTest {
 	
 	@Before
 	public void setup() throws Exception {
+		KeyStore trustStore = DtlsTestTools.loadKeyStore(DtlsTestTools.TRUST_STORE_LOCATION, DtlsTestTools.TRUST_STORE_PASSWORD);
+		Certificate[] trustedCertificates = new Certificate[trustStore.size()];
+		int j = 0;
+		for (Enumeration<String> e = trustStore.aliases(); e.hasMoreElements(); ) {
+			trustedCertificates[j++] = trustStore.getCertificate(e.nextElement());
+		}
+		
 		session = new DTLSSession(endpoint, false);
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder(endpoint);
 		builder.setIdentity(privateKey, publicKey)
 			.setPskStore(new StaticPskStore("client", "secret".getBytes()))
-			.setTrustStore(new Certificate[]{});
+			.setTrustStore(trustedCertificates);
 		handshaker = new ServerHandshaker(session, null, builder.build());
 
 		DatagramWriter writer = new DatagramWriter();


### PR DESCRIPTION
I made some [tests](https://github.com/eclipse/leshan/blob/x509-cert-impl/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java#L349)  with Leshan and if I configure a client with RPK only and a server with X509 only, the DTLS handshake fails.
``` java
// client config
config.setIdentity(clientPrivateKey, clientPublicKey);

// server config
config.setIdentity(privatekey, X509CertChain, false);
config.setTrustStore(trustedCertificates);
```
the [reverse](https://github.com/eclipse/leshan/blob/x509-cert-impl/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java#L367) fails too.

This is due to a bad certification types extensions setting.

This PR should fix the problem and  the certificates types extensions setting is made according the DtlsConnectorConfig.

