### PR TITLE
Fix some exceptions

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -351,7 +351,9 @@ public final class CertificateMessage extends HandshakeMessage {
 		PublicKey publicKey = null;
 
 		if (rawPublicKeyBytes == null) {
-			publicKey = certificateChain[0].getPublicKey();
+			if (certificateChain != null && certificateChain.length > 0) {
+				publicKey = certificateChain[0].getPublicKey();
+			}// else : no public key in this certificate message
 		} else {
 			// get server's public key from Raw Public Key
 			EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(rawPublicKeyBytes);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -330,9 +330,9 @@ public class ServerHandshaker extends Handshaker {
 		clientCertificate = message;
 		clientCertificate.verifyCertificate(rootCertificates);
 		clientPublicKey = clientCertificate.getPublicKey();
-		if (message.getCertificateChain() != null) {
+		if (message.getCertificateChain() != null && message.getCertificateChain().length > 0) {
 			peerCertificate = (X509Certificate) message.getCertificateChain()[0];
-		}	
+		}
 		// TODO why don't we also update the MessageDigest at this point?
 		handshakeMessages = ByteArrayUtils.concatenate(handshakeMessages, clientCertificate.getRawMessage());
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedEllipticCurvesExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedEllipticCurvesExtension.java
@@ -104,8 +104,12 @@ public class SupportedEllipticCurvesExtension extends HelloExtension {
 		sb.append("\t\t\t\tElliptic Curves (" + ellipticCurveList.size() + " curves):\n");
 
 		for (Integer curveId : ellipticCurveList) {
-			String curveName = ECDHECryptography.NAMED_CURVE_TABLE[curveId];
-			sb.append("\t\t\t\t\tElliptic Curve: " + curveName + " (" + curveId + ")\n");
+			if (0 < curveId && curveId < ECDHECryptography.NAMED_CURVE_TABLE.length) {
+				String curveName = ECDHECryptography.NAMED_CURVE_TABLE[curveId];
+				sb.append("\t\t\t\t\tElliptic Curve: " + curveName + " (" + curveId + ")\n");
+			} else {
+				sb.append("\t\t\t\t\tElliptic Curve: unknown (" + curveId + ")\n");
+			}
 		}
 
 		return sb.toString();


### PR DESCRIPTION
I tested scandium with mbedTLS and encountered some little issues, so I fixed it : 

1) mbedTLS use strange curves like brainpoolP512r1(28), scandium crash with an ArrayIndexOutOfBoundsException. [In theory, this should not happened](http://tools.ietf.org/html/rfc4492#section-5.1.1) but in real life ...

2) A [certificate message](https://tools.ietf.org/html/rfc5246#section-7.4.6) could be empty, so I fixed some ArrayIndexOutOfBounds/NPE.

The 2 commits are independent, so they could be cherry picked independently if needed.