### PR TITLE
Fix IllegalArgumentException when stop/start connector

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -344,6 +344,7 @@ public class DTLSConnector implements Connector {
 		outboundMessages.clear();
 		if (socket != null) {
 			socket.close();
+			socket = null;
 		}
 		maximumTransmissionUnit = 0;
 	}


### PR DESCRIPTION
If you start/stop a CoAP endpoint with a DTLSConnector.
You get a :
```
Exception in thread "Thread-4" java.lang.IllegalArgumentException: port out of range:-1
	at java.net.InetSocketAddress.checkPort(InetSocketAddress.java:143)
	at java.net.InetSocketAddress.<init>(InetSocketAddress.java:188)
	at org.eclipse.californium.scandium.DTLSConnector.getAddress(DTLSConnector.java:1210)
	at org.eclipse.californium.core.network.CoAPEndpoint.getAddress(CoAPEndpoint.java:445)
	at org.eclipse.californium.core.network.CoAPEndpoint.start(CoAPEndpoint.java:257)
	at org.eclipse.californium.core.CoapServer.start(CoapServer.java:192)
```