### PR TITLE
add unit test for a client which crash during an handshake

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -413,7 +413,12 @@ public class DTLSConnector implements Connector {
 					processChangeCipherSpecRecord(peerAddress, record);
 					break;
 				case HANDSHAKE:
-					processHandshakeRecord(peerAddress, record);
+					try{
+						processHandshakeRecord(peerAddress, record);	
+					}catch (RuntimeException e){
+						LOGGER.log(Level.INFO, String.format("Aborting handshake with peer %s because of unexpected exception",peerAddress), e);
+						terminateOngoingHandshake(peerAddress, new AlertMessage(AlertLevel.FATAL,AlertDescription.INTERNAL_ERROR,peerAddress));
+					}
 				}
 			} catch (InvalidMacException e) {
 				// this means that the message from the record could not be authenticated

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -78,6 +78,7 @@ import org.eclipse.californium.scandium.dtls.HelloVerifyRequest;
 import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.MaxFragmentLengthExtension;
 import org.eclipse.californium.scandium.dtls.ProtocolVersion;
+import org.eclipse.californium.scandium.dtls.Random;
 import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.ResumingClientHandshaker;
 import org.eclipse.californium.scandium.dtls.ResumingServerHandshaker;
@@ -652,41 +653,43 @@ public class DTLSConnector implements Connector {
 		LOGGER.log(Level.FINER, "Received HANDSHAKE record from peer [{0}]", peerAddress);
 		DTLSFlight flight;
 		Connection connection = connectionStore.get(peerAddress);
-		if (connection != null && connection.getOngoingHandshake() != null) {
-			// we are already in an ongoing handshake
-			// simply delegate the processing of the record to the handshaker
-			flight = connection.getOngoingHandshake().processMessage(record);
-		} else {
 
-			if (record.getEpoch()>0){
-				if (connection != null && connection.getEstablishedSession() != null){
-					// we received a record with Epoch > 0 and we have an established session
-					// so, we use it to decrypt the handshake message.
-					record.setSession(connection.getEstablishedSession());
-				}
-				else
-				{
-					LOGGER.log(Level.FINER, "Discarding unexpected handshake message with epoch > 0 from peer [{0}] with no session established.",
-							new Object[]{peerAddress});
-					return;
-				}
+		// Get session to decode record correctly
+		if (connection != null && connection.getOngoingHandshake()!=null){	
+			record.setSession(connection.getOngoingHandshake().getSession());
+		}else if (record.getEpoch()>0){
+			if (connection != null && connection.getEstablishedSession() != null){
+				// we received a record with Epoch > 0 and we have an established session
+				// so, we use it to decrypt the handshake message.
+				record.setSession(connection.getEstablishedSession());
 			}
+			else{
+				LOGGER.log(Level.FINER, "Discarding unexpected handshake message with epoch > 0 from peer [{0}] with no session established.",
+						new Object[]{peerAddress});
+				return;
+			}
+		}
 
-			HandshakeMessage handshakeMessage = (HandshakeMessage) record.getFragment();
+		HandshakeMessage handshakeMessage = (HandshakeMessage) record.getFragment();
 
-			switch (handshakeMessage.getMessageType()) {
-			case HELLO_REQUEST:
-				// Peer (server) wants us (client) to initiate (re-)negotiation of session
-				flight = processHelloRequest(connection, record);
-				break;
+		switch (handshakeMessage.getMessageType()) {
+		case HELLO_REQUEST:
+			// Peer (server) wants us (client) to initiate (re-)negotiation of session
+			flight = processHelloRequest(connection, record);
+			break;
 
-			case CLIENT_HELLO:
-				// Peer (client) wants to either resume an existing session
-				// or wants to negotiate a new session with us (server)
-				flight = processClientHello(connection, record);
-				break;
+		case CLIENT_HELLO:
+			// Peer (client) wants to either resume an existing session
+			// or wants to negotiate a new session with us (server)
+			flight = processClientHello(connection, record);
+			break;
 
-			default:
+		default:
+			if (connection != null && connection.getOngoingHandshake() != null) {
+				// we are already in an handshake 
+				// simply delegate the processing of the record to the handshaker
+				flight = connection.getOngoingHandshake().processMessage(record);
+			}else{
 				LOGGER.log(Level.FINER, "Discarding unexpected handshake message of type [{0}] from peer [{1}]",
 						new Object[]{handshakeMessage.getMessageType(), peerAddress});
 				return;
@@ -738,6 +741,19 @@ public class DTLSConnector implements Connector {
 		
 		DTLSFlight nextFlight = null;
 		Connection peerConnection = connection;
+		
+ 		if (connection != null && connection.getOngoingHandshake() instanceof ServerHandshaker) {
+			// we have an ongoing handshake, so we try to find if this CLIENT_HELLO is a retransmission or a fresh new handshake 
+			ClientHello clientHello = (ClientHello) record.getFragment();
+			ServerHandshaker handshaker = (ServerHandshaker) connection.getOngoingHandshake();
+			Random messageRandom = clientHello.getRandom();
+			Random serverHandshaker = handshaker.getClientRandom();
+			// we already receive a CLIENT_HELLO with this random, so this is surely a retransmission,
+			// let handshaker handle this.
+			if (Arrays.equals(messageRandom.getRandomBytes(), serverHandshaker.getRandomBytes())) {
+				return connection.getOngoingHandshake().processMessage(record);
+			}// else handle this like fresh new CLIENT_HELLO
+		}
 		
 		if (record.getEpoch() > 0) {
 			// client tries to re-negotiate new crypto params for existing session

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
@@ -341,7 +341,7 @@ public final class ClientHello extends HandshakeMessage {
 		return cookie;
 	}
 
-	void setCookie(byte[] cookie) {
+	public void setCookie(byte[] cookie) {
 		this.cookie = Arrays.copyOf(cookie, cookie.length);
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -877,4 +877,8 @@ public class ServerHandshaker extends Handshaker {
 	final SupportedGroup getNegotiatedSupportedGroup() {
 		return negotiatedSupportedGroup;
 	}
+
+	public Random getClientRandom(){
+		return clientRandom;
+	}
 }


### PR DESCRIPTION
We have some issue with the last version of scandium when we try to start a fresh new handshake while the first one is still ongoing. (This could happen if the device crash during the handshake then restart a new handshake on the same IP)
In this case, the client will not be able to rehandshake as long as the session in stored.

I just create the test case corresponding to the issue, this will allow to start discussion.
This is the current exchange :

```
 ---> CLIENT_HELLO ( no cookie + PSK)
<--- HELLO_VERY_REQUEST (cookie)
---> CLIENT_HELLO (cookie +  PSK)
<-- SERVER_HELLO ( PSK), SERVER HELLO DONE  
***** crash / restart *****
---> CLIENT_HELLO (no cookie +RPK)
// Discarded by the server handshaker duplicate message
<--- retransmission SERVER_HELLO ( PSK), SERVER HELLO DONE  
// X NPE at client side (field pskStore is null at ClientHandshaker.java:499) 
etc etc  ...
```

There is several issue : 
1) The `pskStore` NPE.
2) A `CLIENT_HELLO` with no cookie is handle by the handshaker, this expose us to IP spoofing attack during handshake.
3) We discard the new `CLIENT_HELLO`, so we are unable to start a fresh new handshake.

Possible solution : 
1) test if `pskStore` is null or always create an empty pskStore.
2) always send HELLO_VERY_REQUEST if we receive a CLIENT_HELLO without cookie (even if an hanshake is ongoing)
3) The hardest one ... Does we restart a fresh new handshake earh time we receive a CLIENT_HELLO with cookie ? If we do that we could restart handshake because of duplicated/badly ordered message? I don't know if we could do something better ?

(Do not merger this one, while we don't provide fix for this issue)
